### PR TITLE
feat: make Zsh setup cross-platform and update .zshrc config

### DIFF
--- a/install-zsh.sh
+++ b/install-zsh.sh
@@ -78,27 +78,36 @@ detect_os() {
 
 install_zsh_linux() {
   local os_id="$1"
+  local sudo_cmd=()
   log_info "Detected Linux distribution: $os_id"
+
+  if [[ $EUID -ne 0 ]]; then
+    if ! command -v sudo >/dev/null 2>&1; then
+      log_error "Package installation requires root privileges or sudo. Re-run as root or install sudo."
+      exit 1
+    fi
+    sudo_cmd=(sudo)
+  fi
 
   if command -v apt-get >/dev/null 2>&1; then
     log_info "Installing Zsh via apt..."
-    DEBIAN_FRONTEND=noninteractive sudo apt-get update -y
-    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y zsh
+    DEBIAN_FRONTEND=noninteractive "${sudo_cmd[@]}" apt-get update -y
+    DEBIAN_FRONTEND=noninteractive "${sudo_cmd[@]}" apt-get install -y zsh
   elif command -v dnf >/dev/null 2>&1; then
     log_info "Installing Zsh via dnf..."
-    sudo dnf install -y zsh
+    "${sudo_cmd[@]}" dnf install -y zsh
   elif command -v yum >/dev/null 2>&1; then
     log_info "Installing Zsh via yum..."
-    sudo yum install -y zsh
+    "${sudo_cmd[@]}" yum install -y zsh
   elif command -v pacman >/dev/null 2>&1; then
     log_info "Installing Zsh via pacman..."
-    sudo pacman -Sy --noconfirm zsh
+    "${sudo_cmd[@]}" pacman -Sy --noconfirm zsh
   elif command -v apk >/dev/null 2>&1; then
     log_info "Installing Zsh via apk..."
-    sudo apk add zsh
+    "${sudo_cmd[@]}" apk add zsh
   elif command -v zypper >/dev/null 2>&1; then
     log_info "Installing Zsh via zypper..."
-    sudo zypper install -y zsh
+    "${sudo_cmd[@]}" zypper install -y zsh
   else
     log_error "No supported package manager found. Install zsh manually."
     exit 1

--- a/install-zsh.sh
+++ b/install-zsh.sh
@@ -3,11 +3,12 @@
 ###############################################################################
 # inbash :: install-zsh.sh
 # ---------------------------------------------------------------------------
-# Description : Installs Zsh, sets it as the default shell (optional) and
-#               fetches Oh My Zsh using the official installer.
+# Description : Installs Zsh (if needed), sets it as the default shell
+#               (optional), and fetches Oh My Zsh using the official installer.
+#               Works on Debian/Ubuntu, Fedora/RHEL, Arch, macOS, and WSL.
 # Usage       : ./install-zsh.sh [-y|--yes] [--set-default]
 # Example     : ./install-zsh.sh --yes --set-default
-# Requirements: Debian/Ubuntu based system with apt, curl, and sudo or root.
+# Requirements: curl, and root/sudo for package installation.
 ###############################################################################
 
 set -euo pipefail
@@ -31,7 +32,7 @@ Options:
       --set-default Switch current user to Zsh after installation.
   -h, --help        Show this help message.
 
-The script installs Zsh and Oh My Zsh using apt and the upstream installer.
+The script detects your OS and installs Zsh + Oh My Zsh accordingly.
 EOF
 }
 
@@ -64,25 +65,66 @@ ensure_command() {
   fi
 }
 
-ensure_command apt-get
-ensure_command curl
-
-if [[ ${EUID:-0} -ne 0 ]]; then
-  if command -v sudo >/dev/null 2>&1; then
-    SUDO="sudo"
+detect_os() {
+  if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    echo "$ID"
+  elif [[ "$(uname -s)" == "Darwin" ]]; then
+    echo "darwin"
   else
-    log_error "This script requires root privileges or sudo access."
+    echo "unknown"
+  fi
+}
+
+install_zsh_linux() {
+  local os_id="$1"
+  log_info "Detected Linux distribution: $os_id"
+
+  if command -v apt-get >/dev/null 2>&1; then
+    log_info "Installing Zsh via apt..."
+    DEBIAN_FRONTEND=noninteractive sudo apt-get update -y
+    DEBIAN_FRONTEND=noninteractive sudo apt-get install -y zsh
+  elif command -v dnf >/dev/null 2>&1; then
+    log_info "Installing Zsh via dnf..."
+    sudo dnf install -y zsh
+  elif command -v yum >/dev/null 2>&1; then
+    log_info "Installing Zsh via yum..."
+    sudo yum install -y zsh
+  elif command -v pacman >/dev/null 2>&1; then
+    log_info "Installing Zsh via pacman..."
+    sudo pacman -Sy --noconfirm zsh
+  elif command -v apk >/dev/null 2>&1; then
+    log_info "Installing Zsh via apk..."
+    sudo apk add zsh
+  elif command -v zypper >/dev/null 2>&1; then
+    log_info "Installing Zsh via zypper..."
+    sudo zypper install -y zsh
+  else
+    log_error "No supported package manager found. Install zsh manually."
     exit 1
   fi
-else
-  SUDO=""
-fi
+}
+
+install_zsh_macos() {
+  log_info "Detected macOS."
+  if command -v brew >/dev/null 2>&1; then
+    log_info "Installing Zsh via Homebrew..."
+    brew install zsh
+  elif command -v apt-get >/dev/null 2>&1; then
+    # WSL on macOS
+    install_zsh_linux "wsl"
+  else
+    log_error "Homebrew not found. Please install Homebrew first: https://brew.sh"
+    exit 1
+  fi
+}
+
+# --- Main ---
 
 if [[ $AUTO_APPROVE -eq 0 ]]; then
   read -r -p "Install Zsh and Oh My Zsh now? [y/N] " response
   case "$response" in
-    [yY][eE][sS]|[yY])
-      ;;
+    [yY][eE][sS]|[yY]) ;;
     *)
       log_warn "Installation aborted by user."
       exit 0
@@ -90,37 +132,64 @@ if [[ $AUTO_APPROVE -eq 0 ]]; then
   esac
 fi
 
-log_info "Updating apt package index..."
-DEBIAN_FRONTEND=noninteractive $SUDO apt-get update -y
+if ! command -v zsh >/dev/null 2>&1; then
+  log_info "Zsh is not installed. Installing..."
 
-log_info "Installing Zsh..."
-DEBIAN_FRONTEND=noninteractive $SUDO apt-get install -y zsh
+  if [[ $AUTO_APPROVE -eq 0 ]]; then
+    echo "This script requires sudo for package installation."
+    read -r -p "Proceed? [y/N] " response
+    case "$response" in
+      [yY][eE][sS]|[yY]) ;;
+      *)
+        log_warn "Installation aborted by user."
+        exit 0
+        ;;
+    esac
+  fi
 
-log_info "Downloading Oh My Zsh installer to a secure temporary location..."
-installer_path="$(mktemp -t ohmyzsh-installer-XXXXXX.sh)"
-
-trap 'rm -f "$installer_path"' EXIT
-
-curl -fsSL "$OH_MY_ZSH_INSTALLER_URL" -o "$installer_path"
-chmod 700 "$installer_path"
-
-log_warn "The installer was fetched from $OH_MY_ZSH_INSTALLER_URL"
-log_warn "Review the script at '$installer_path' before proceeding."
-
-if [[ $AUTO_APPROVE -eq 0 ]]; then
-  read -r -p "Run the Oh My Zsh installer now? [y/N] " response
-  case "$response" in
-    [yY][eE][sS]|[yY])
-      ;;
-    *)
-      log_warn "Skipping Oh My Zsh installation as requested."
-      exit 0
-      ;;
-  esac
+  local_os="$(detect_os)"
+  if [[ "$local_os" == "darwin" ]]; then
+    install_zsh_macos
+  else
+    install_zsh_linux "$local_os"
+  fi
+else
+  log_info "Zsh is already installed: $(command -v zsh)"
 fi
 
-log_info "Running Oh My Zsh installer..."
-RUNZSH="no" CHSH="no" KEEP_ZSHRC="yes" sh "$installer_path"
+# --- Oh My Zsh ---
+
+if [[ -d "$HOME/.oh-my-zsh" ]]; then
+  log_info "Oh My Zsh is already installed at $HOME/.oh-my-zsh"
+else
+  log_info "Downloading Oh My Zsh installer to a secure temporary location..."
+  installer_path="$(mktemp -t ohmyzsh-installer-XXXXXX.sh)"
+
+  trap 'rm -f "$installer_path"' EXIT
+
+  ensure_command curl
+  curl -fsSL "$OH_MY_ZSH_INSTALLER_URL" -o "$installer_path"
+  chmod 700 "$installer_path"
+
+  log_warn "The installer was fetched from $OH_MY_ZSH_INSTALLER_URL"
+  log_warn "Review the script at '$installer_path' before proceeding."
+
+  if [[ $AUTO_APPROVE -eq 0 ]]; then
+    read -r -p "Run the Oh My Zsh installer now? [y/N] " response
+    case "$response" in
+      [yY][eE][sS]|[yY]) ;;
+      *)
+        log_warn "Skipping Oh My Zsh installation as requested."
+        exit 0
+        ;;
+    esac
+  fi
+
+  log_info "Running Oh My Zsh installer..."
+  RUNZSH="no" CHSH="no" KEEP_ZSHRC="yes" sh "$installer_path"
+fi
+
+# --- Set default shell (optional) ---
 
 if [[ $SET_DEFAULT_SHELL -eq 1 ]]; then
   if chsh -s "$(command -v zsh)" "$USER"; then

--- a/setup-ohMyZsh.sh
+++ b/setup-ohMyZsh.sh
@@ -5,6 +5,7 @@
 # ---------------------------------------------------------------------------
 # Description : Installs recommended Oh My Zsh community plugins and copies a
 #               curated .zshrc configuration for the current user.
+#               Works on any Linux/macOS machine with Oh My Zsh installed.
 # Usage       : ./setup-ohMyZsh.sh [-y|--yes] [--config <path>]
 # Example     : ./setup-ohMyZsh.sh --yes --config ./zshrc-config
 # Requirements: git, curl (for Oh My Zsh), existing Oh My Zsh installation.
@@ -117,11 +118,15 @@ for plugin_repo in "${DEFAULT_PLUGINS[@]}"; do
   clone_plugin "$plugin_repo"
 done
 
+# --- Backup existing .zshrc ---
+
 backup_path="$HOME/.zshrc.$(date +%Y%m%d%H%M%S).bak"
 if [[ -f "$HOME/.zshrc" ]]; then
   log_info "Backing up existing ~/.zshrc to '$backup_path'."
   cp "$HOME/.zshrc" "$backup_path"
 fi
+
+# --- Copy config ---
 
 log_info "Copying config from '$CONFIG_SOURCE' to '$HOME/.zshrc'."
 cp "$CONFIG_SOURCE" "$HOME/.zshrc"

--- a/zshrc-config
+++ b/zshrc-config
@@ -49,7 +49,9 @@ fi
 # Homebrew (macOS / Linuxbrew)
 # =================================================================
 if command -v brew >/dev/null 2>&1; then
-  eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /home/linuxbrew/.linuxbrew/bin/brew shellenv 2>/dev/null)"
+  _BREW_BIN="$(command -v brew)"
+  eval "$("$_BREW_BIN" shellenv 2>/dev/null)"
+  unset _BREW_BIN
 fi
 
 # =================================================================
@@ -94,12 +96,15 @@ fi
 # AI Coding Assistants (optional — only adds to PATH if present)
 # =================================================================
 
+_COMPLETION_CACHE_DIR="$HOME/.local/share"
+
 # Claude Code (Anthropic)
 # Installed via: npm i -g @anthropic-ai/claude-code  OR  pipx install claude-code
 if command -v claude >/dev/null 2>&1; then
   # Generate and source shell completion (one-time, cached)
-  _CLAUDE_COMP="$HOME/.local/share/claude-shell-completion.zsh"
+  _CLAUDE_COMP="$_COMPLETION_CACHE_DIR/claude-shell-completion.zsh"
   if [ ! -f "$_CLAUDE_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
     claude completion zsh > "$_CLAUDE_COMP" 2>/dev/null || true
   fi
   [ -s "$_CLAUDE_COMP" ] && source "$_CLAUDE_COMP"
@@ -110,8 +115,9 @@ fi
 if command -v codex >/dev/null 2>&1; then
   export PATH="$HOME/.codex/bin:$PATH"
   # Generate and source shell completion (one-time, cached)
-  _CODEX_COMP="$HOME/.local/share/codex-shell-completion.zsh"
+  _CODEX_COMP="$_COMPLETION_CACHE_DIR/codex-shell-completion.zsh"
   if [ ! -f "$_CODEX_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
     codex completion zsh > "$_CODEX_COMP" 2>/dev/null || true
   fi
   [ -s "$_CODEX_COMP" ] && source "$_CODEX_COMP"
@@ -121,12 +127,15 @@ fi
 # Installed via: npm i -g @earendil-works/pi-coding-agent
 if command -v pi >/dev/null 2>&1; then
   # Generate and source shell completion (one-time, cached)
-  _PI_COMP="$HOME/.local/share/pi-shell-completion.zsh"
+  _PI_COMP="$_COMPLETION_CACHE_DIR/pi-shell-completion.zsh"
   if [ ! -f "$_PI_COMP" ]; then
+    mkdir -p "$_COMPLETION_CACHE_DIR"
     pi completion zsh > "$_PI_COMP" 2>/dev/null || true
   fi
   [ -s "$_PI_COMP" ] && source "$_PI_COMP"
 fi
+
+unset _COMPLETION_CACHE_DIR _CLAUDE_COMP _CODEX_COMP _PI_COMP
 
 # =================================================================
 # NVM (Node Version Manager) — optional

--- a/zshrc-config
+++ b/zshrc-config
@@ -1,104 +1,159 @@
+# =================================================================
+# inbash :: Generic .zshrc
+# -----------------------------------------------------------------
+# A portable Zsh configuration for Linux & macOS machines.
+# Works with Oh My Zsh and common developer toolchains.
+# =================================================================
+
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:/usr/local/bin:$PATH
 
 # Path to your oh-my-zsh installation.
-export ZSH="/home/ubuntu/.oh-my-zsh"
+export ZSH="$HOME/.oh-my-zsh"
 
-# Set name of the theme to load --- if set to "random", it will
-# load a random theme each time oh-my-zsh is loaded, in which case,
-# to know which specific one was loaded, run: echo $RANDOM_THEME
-# See https://github.com/ohmyzsh/ohmyzsh/wiki/Themes
+# Set name of the theme to load.
 ZSH_THEME="wedisagree"
-
-# Set list of themes to pick from when loading at random
-# Setting this variable when ZSH_THEME=random will cause zsh to load
-# a theme from this variable instead of looking in ~/.oh-my-zsh/themes/
-# If set to an empty array, this variable will have no effect.
-# ZSH_THEME_RANDOM_CANDIDATES=( "robbyrussell" "agnoster" )
-
-# Uncomment the following line to use case-sensitive completion.
-# CASE_SENSITIVE="true"
-
-# Uncomment the following line to use hyphen-insensitive completion.
-# Case-sensitive completion must be off. _ and - will be interchangeable.
-# HYPHEN_INSENSITIVE="true"
-
-# Uncomment the following line to disable bi-weekly auto-update checks.
-# DISABLE_AUTO_UPDATE="true"
-
-# Uncomment the following line to automatically update without prompting.
-# DISABLE_UPDATE_PROMPT="true"
-
-# Uncomment the following line to change how often to auto-update (in days).
-# export UPDATE_ZSH_DAYS=13
-
-# Uncomment the following line if pasting URLs and other text is messed up.
-# DISABLE_MAGIC_FUNCTIONS=true
-
-# Uncomment the following line to disable colors in ls.
-# DISABLE_LS_COLORS="true"
-
-# Uncomment the following line to disable auto-setting terminal title.
-# DISABLE_AUTO_TITLE="true"
 
 # Uncomment the following line to enable command auto-correction.
 ENABLE_CORRECTION="true"
 
-# Uncomment the following line to display red dots whilst waiting for completion.
-# COMPLETION_WAITING_DOTS="true"
-
-# Uncomment the following line if you want to disable marking untracked files
-# under VCS as dirty. This makes repository status check for large repositories
-# much, much faster.
-# DISABLE_UNTRACKED_FILES_DIRTY="true"
-
-# Uncomment the following line if you want to change the command execution time
-# stamp shown in the history command output.
-# You can set one of the optional three formats:
-# "mm/dd/yyyy"|"dd.mm.yyyy"|"yyyy-mm-dd"
-# or set a custom format using the strftime function format specifications,
-# see 'man strftime' for details.
-# HIST_STAMPS="mm/dd/yyyy"
-
-# Would you like to use another custom folder than $ZSH/custom?
-# ZSH_CUSTOM=/path/to/new-custom-folder
-
 # Which plugins would you like to load?
 # Standard plugins can be found in ~/.oh-my-zsh/plugins/*
 # Custom plugins may be added to ~/.oh-my-zsh/custom/plugins/
-# Example format: plugins=(rails git textmate ruby lighthouse)
-# Add wisely, as too many plugins slow down shell startup.
 plugins=(
-	git
-	zsh-syntax-highlighting
-	zsh-autosuggestions
-	zsh-completions
+  git
+  zsh-syntax-highlighting
+  zsh-autosuggestions
+  zsh-completions
 )
 
 source $ZSH/oh-my-zsh.sh
 
+# =================================================================
+# Starship prompt (cross-platform, installed via brew / curl / etc.)
+# =================================================================
+if command -v starship >/dev/null 2>&1; then
+  eval "$(starship init zsh)"
+fi
+
+# =================================================================
 # User configuration
-
-# export MANPATH="/usr/local/man:$MANPATH"
-
-# You may need to manually set your language environment
-# export LANG=en_US.UTF-8
-
-# Preferred editor for local and remote sessions
-# if [[ -n $SSH_CONNECTION ]]; then
-#   export EDITOR='vim'
-# else
-#   export EDITOR='mvim'
-# fi
-
-# Compilation flags
-# export ARCHFLAGS="-arch x86_64"
+# =================================================================
 
 # Set personal aliases, overriding those provided by oh-my-zsh libs,
 # plugins, and themes. Aliases can be placed here, though oh-my-zsh
 # users are encouraged to define aliases within the ZSH_CUSTOM folder.
 # For a full list of active aliases, run `alias`.
-#
-# Example aliases
-# alias zshconfig="mate ~/.zshrc"
-# alias ohmyzsh="mate ~/.oh-my-zsh"
+
+# =================================================================
+# Homebrew (macOS / Linuxbrew)
+# =================================================================
+if command -v brew >/dev/null 2>&1; then
+  eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /home/linuxbrew/.linuxbrew/bin/brew shellenv 2>/dev/null)"
+fi
+
+# =================================================================
+# Python (homebrew / system)
+# =================================================================
+# Homebrew Python on macOS (Apple Silicon)
+if [ -d "/opt/homebrew/Frameworks/Python.framework/Versions" ]; then
+  for ver in /opt/homebrew/Frameworks/Python.framework/Versions/*/bin; do
+    case ":$PATH:" in
+      *":$ver:"*) ;; *) export PATH="$ver:$PATH";;
+    esac
+  done
+fi
+
+# Homebrew Python on macOS (Intel)
+if [ -d "/usr/local/Frameworks/Python.framework/Versions" ]; then
+  for ver in /usr/local/Frameworks/Python.framework/Versions/*/bin; do
+    case ":$PATH:" in
+      *":$ver:"*) ;; *) export PATH="$ver:$PATH";;
+    esac
+  done
+fi
+
+# Python 3.10 system path (macOS legacy)
+if [ -d "/Library/Frameworks/Python.framework/Versions/3.10/bin" ]; then
+  PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:${PATH}"
+  export PATH
+fi
+
+# =================================================================
+# pipx / user-local binaries
+# =================================================================
+if [ -d "$HOME/.local/bin" ]; then
+  export PATH="$HOME/.local/bin:$PATH"
+fi
+
+# =================================================================
+# Developer CLI tools (optional — only adds to PATH if present)
+# =================================================================
+
+# =================================================================
+# AI Coding Assistants (optional — only adds to PATH if present)
+# =================================================================
+
+# Claude Code (Anthropic)
+# Installed via: npm i -g @anthropic-ai/claude-code  OR  pipx install claude-code
+if command -v claude >/dev/null 2>&1; then
+  # Generate and source shell completion (one-time, cached)
+  _CLAUDE_COMP="$HOME/.local/share/claude-shell-completion.zsh"
+  if [ ! -f "$_CLAUDE_COMP" ]; then
+    claude completion zsh > "$_CLAUDE_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_CLAUDE_COMP" ] && source "$_CLAUDE_COMP"
+fi
+
+# Codex CLI (OpenAI)
+# Installed via: npm i -g @openai/codex
+if command -v codex >/dev/null 2>&1; then
+  export PATH="$HOME/.codex/bin:$PATH"
+  # Generate and source shell completion (one-time, cached)
+  _CODEX_COMP="$HOME/.local/share/codex-shell-completion.zsh"
+  if [ ! -f "$_CODEX_COMP" ]; then
+    codex completion zsh > "$_CODEX_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_CODEX_COMP" ] && source "$_CODEX_COMP"
+fi
+
+# Pi (Pi.dev — Pi Coding Agent)
+# Installed via: npm i -g @earendil-works/pi-coding-agent
+if command -v pi >/dev/null 2>&1; then
+  # Generate and source shell completion (one-time, cached)
+  _PI_COMP="$HOME/.local/share/pi-shell-completion.zsh"
+  if [ ! -f "$_PI_COMP" ]; then
+    pi completion zsh > "$_PI_COMP" 2>/dev/null || true
+  fi
+  [ -s "$_PI_COMP" ] && source "$_PI_COMP"
+fi
+
+# =================================================================
+# NVM (Node Version Manager) — optional
+# =================================================================
+if [ -s "$HOME/.nvm/nvm.sh" ]; then
+  export NVM_DIR="$HOME/.nvm"
+  . "$NVM_DIR/nvm.sh"
+elif [ -s "/usr/local/share/nvm/nvm.sh" ]; then
+  export NVM_DIR="/usr/local/share/nvm"
+  . "$NVM_DIR/nvm.sh"
+fi
+
+# =================================================================
+# Pyenv — optional
+# =================================================================
+if command -v pyenv >/dev/null 2>&1; then
+  export PYENV_ROOT="$HOME/.pyenv"
+  export PATH="$PYENV_ROOT/bin:$PATH"
+  if command -v pyenv >/dev/null 2>&1; then
+    eval "$(pyenv init --path)"
+    eval "$(pyenv init -)"
+  fi
+fi
+
+# =================================================================
+# Direnv — optional
+# =================================================================
+if command -v direnv >/dev/null 2>&1; then
+  eval "$(direnv hook zsh)"
+fi


### PR DESCRIPTION
## Changes

### `install-zsh.sh`
- **OS auto-detection**: Detects macOS (via `uname`) and Linux distros (via `/etc/os-release`)
- **Multi-distro support**: apt, dnf, yum, pacman, apk, zypper
- **macOS support**: Installs via Homebrew (with WSL fallback)
- **Idempotent**: Skips Zsh/Oh My Zsh if already installed
- **Safe**: Requires confirmation unless `-y` is passed

### `setup-ohMyZsh.sh`
- Updated documentation to reflect cross-platform support
- No behavioral changes (already generic)

### `zshrc-config`
- **Generic paths**: Replaced machine-specific paths (`/home/ubuntu`, `/opt/homebrew`) with `$HOME` and conditional detection
- **Starship**: Conditionally initialized (only if installed)
- **Homebrew**: Tries both Apple Silicon (`/opt/homebrew`) and Linuxbrew (`/home/linuxbrew/.linuxbrew`)
- **Python**: Handles Homebrew Python on Apple Silicon, Intel Mac, and legacy system paths
- **pipx**: `$HOME/.local/bin`
- **AI Coding Assistants** (new): Claude Code, Codex CLI, and Pi — all detected via `command -v`, with cached shell completions
- **Optional toolchains** (conditional): NVM, Pyenv, Direnv
- **Removed**: Bun, Opencode, Grok

## Testing
- `install-zsh.sh` tested on macOS with Homebrew
- `zshrc-config` validated against current machine's active configuration
- Scripts use `set -euo pipefail` for safety